### PR TITLE
Add AI Atlas Nexus (IBM) — AI governance toolkit and research paper

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ AI is a transformative and dual-side technology prone to reshape industries, yet
 ### Artificial Intelligence Governance (AI Governance)
 
 - Eisenberg, I. W. et al. (2025). **The Unified Control Framework: Establishing a Common Foundation for Enterprise AI Governance, Risk Management and Regulatory Compliance**. arXiv preprint arXiv:2503.05937. [Article](https://arxiv.org/abs/2503.05937) [Visualization](https://ianatcredoai.github.io/UCF_Figures/) `Credo`
+- Bagehorn, F. et al. (2025). **AI Risk Atlas: Taxonomy and Tooling for Navigating AI Risks and Resources**. arXiv preprint arXiv:2503.05780. [Article](https://arxiv.org/abs/2503.05780) `IBM`
 
 ### Bias
 
@@ -786,6 +787,7 @@ This section is under review and the rest of entries will be added to the table 
 ### AI Governance
 
 - [Governance Mega-Map Application](https://github.com/The-Company-Ethos/doing-ai-governance) `The Company Ethos`
+- [AI Atlas Nexus](https://github.com/IBM/ai-atlas-nexus) `Python` `IBM`
 
 ### Audit
 


### PR DESCRIPTION
Adds two entries for AI Atlas Nexus, an open-source AI governance toolkit from IBM Research:

**Academic Research > Artificial Intelligence Governance (AI Governance):**
- The arXiv paper describing the AI Risk Atlas taxonomy and the AI Atlas Nexus tooling (2503.05780, 20 authors, AAAI 2025/2026 demo).

**Tools > AI Governance:**
- The AI Atlas Nexus Python library, which uses knowledge graphs and ontologies to unify risk taxonomies (NIST AI RMF, OWASP LLM Top 10, EU AI Act, MIT AI Risk Repository, IBM AI Risk Atlas) for risk identification, prioritization, and compliance automation.

The project is:
- Listed in the [OECD AI Catalogue](https://oecd.ai/en/catalogue/tools/risk-atlas-nexus)
- Part of the [AI Alliance Trust & Safety Evaluation initiative](https://the-ai-alliance.github.io/trust-safety-evals/leaderboards/risk-atlas-nexus/)
- Presented at AAAI 2025 and AAAI 2026
- Has a live [Hugging Face demo](https://huggingface.co/spaces/ibm/risk-atlas-nexus)
- Apache 2.0 licensed, 114 stars, 16 contributors, active development (v1.2.0, Jan 2026)