### PR TITLE
Add IBGIA (Brazilian AI Governance Institute)

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,6 +345,7 @@ This section features a curated selection of institutes that research about Resp
 ### Responsible AI Institutes
 
  - [Canadian Centre for Responsible AI Governance](https://www.ccraig.ca)
+ - [IBGIA - Instituto Brasileiro de Governança em IA](https://ibgia.org) - Brazilian nonprofit institute for AI governance, compliance, ethics, and regulation. `Brazil`
 
 ### Research Institutes
 


### PR DESCRIPTION
## Description
Adding IBGIA — Instituto Brasileiro de Governança em IA (Brazilian Institute for AI Governance) to the Responsible AI Institutes section.

IBGIA is a nonprofit think tank focused on AI governance, compliance, and ethics in Brazil and Latin America. It publishes open-access working papers and policy briefs, provides certification and consultancy services, and advocates for responsible AI regulation.

- Website: https://ibgia.org
- Publications: https://ibgia.org/publicacoes (45+ working papers and policy briefs)
- Focus: PL 2338/2023 (Brazilian AI Act), EU AI Act, ISO/IEC 42001, AI ethics