### PR TITLE
Add AI Job Displacement Tracker to Data Sets section

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,7 @@ This section features a curated selection of open courses focused on Responsible
 
 This section features a curated selection of data sets.
 
+- [AI Job Displacement Tracker](https://github.com/noahaust2/ai-displacement-tracker) - Structured, source-verified dataset of 108 AI-attributed workforce displacement events across 15 countries and 13 sectors (483,000+ workers). Three-tier attribution methodology. JSON/CSV. CC-BY-4.0.
 - [Common Corpus](https://huggingface.co/collections/PleIAs/common-corpus-65d46e3ea3980fdcd66a5613)
 - [An ImageNet replacement for self-supervised pretraining without humans](https://www.robots.ox.ac.uk/~vgg/research/pass/)
 - [Huggingface Data Sets](https://huggingface.co/datasets)


### PR DESCRIPTION
Adds the AI Job Displacement Tracker — a structured dataset tracking AI-driven workforce displacement — to the Data Sets section.\n\n**Dataset:** 108 events, 483,000+ workers, 15 countries, 13 sectors. Source-verified with three-tier attribution (confirmed/probable/unverified). Available in JSON, CSV, and summary formats under CC-BY-4.0.\n\n**Relevance to Responsible AI:** Provides empirical evidence of AI's labor market impact, essential context for responsible AI policy, governance, and impact assessment.