### PR TITLE
Add AIR Blackbox to Audit tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -793,6 +793,7 @@ This section is under review and the rest of entries will be added to the table 
 
 ### Audit
 
+- [AIR Blackbox](https://github.com/airblackbox/gateway) `Python` - Open-source EU AI Act compliance scanner and runtime trust layer for Python AI agents. HMAC-SHA256 tamper-evident audit chains, PII detection, and prompt injection blocking. Trust layers for LangChain, CrewAI, AutoGen, OpenAI, Google ADK, and Claude Agent SDK. ([Website](https://airblackbox.ai) | [PyPI](https://pypi.org/project/air-blackbox/))
 - [glassalpha](https://github.com/asibic/glassalpha) `Python`
 
 ### Causal Inference


### PR DESCRIPTION
Adds [AIR Blackbox](https://github.com/airblackbox/gateway) to the Audit subsection under Tools.

AIR Blackbox is an open-source EU AI Act compliance scanner and runtime trust layer for Python AI agents:

- HMAC-SHA256 tamper-evident audit chains (published formal spec)
- 39 checks across EU AI Act Articles 9-15
- Trust layers for 6 frameworks: LangChain, CrewAI, AutoGen, OpenAI, Google ADK, Claude Agent SDK
- PII detection and prompt injection blocking
- Ships as CLI, MCP server, and GitHub Action
- Apache 2.0 licensed

Website: https://airblackbox.ai
PyPI: https://pypi.org/project/air-blackbox/