### PR TITLE
Add semantix-ai under Audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -831,6 +831,7 @@ Licensing AI models adds new layers of complexity beyond what traditional softwa
 
 - [AIR Blackbox](https://github.com/airblackbox/gateway) `Python` - Open-source EU AI Act compliance scanner and runtime trust layer for Python AI agents. HMAC-SHA256 tamper-evident audit chains, PII detection, and prompt injection blocking. Trust layers for LangChain, CrewAI, AutoGen, OpenAI, Google ADK, and Claude Agent SDK. ([Website](https://airblackbox.ai) | [PyPI](https://pypi.org/project/air-blackbox/))
 - [glassalpha](https://github.com/asibic/glassalpha) `Python`
+- [semantix-ai](https://github.com/labrat-akhona/semantix-ai) `Python` - Open-source library for validating LLM outputs against plain-English intents using local NLI inference. Hash-chained JSON-LD audit certificates (tamper-evident), DSPy/LangChain/Pydantic-AI/Guardrails integrations, pytest plugin. POPIA/GDPR/EU AI Act aligned. ([Docs](https://labrat-akhona.github.io/semantix-ai/) | [PyPI](https://pypi.org/project/semantix-ai/))
 - [Systima Comply](https://github.com/systima-ai/comply) `TypeScript` `Systima`
 
 ### Causal Inference


### PR DESCRIPTION
Adds semantix-ai under Audit.

semantix-ai is an open-source (MIT) Python library for validating LLM outputs against plain-English semantic intents using a local quantized NLI model (~25 MB ONNX, ~15 ms per call, deterministic, no API key).

Why it fits Audit:
- Every validation produces a hash-chained JSON-LD Semantic Certificate. Modifying any entry breaks every subsequent hash — tamper-evident by construction.
- CLI `semantix verify audit.jsonl` re-computes the chain and reports entry counts, pass/fail rates, and top intents.
- Compliance-aligned framing (POPIA §71, GDPR Art. 44, EU AI Act high-risk-system obligations) baked into the design, not retrofitted.
- Drop-in integrations for DSPy, LangChain, Pydantic AI, Guardrails, Instructor, and MCP.

Sits naturally alongside AIR Blackbox (tamper-evident audit chains, trust layer for agent frameworks) and glassalpha.

- Repo: https://github.com/labrat-akhona/semantix-ai
- PyPI: https://pypi.org/project/semantix-ai/
- Docs: https://labrat-akhona.github.io/semantix-ai/
- License: MIT
