### PR TITLE
Add Made by Human to Frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,6 +307,7 @@ This section is under review and the rest of entries will be added to the table 
 - [Data Ethics Canvas](https://theodi.org/insights/tools/the-data-ethics-canvas-2021/) `Open Data Institute`
 - [Deon](https://deon.drivendata.org) `Python` `Drivendata`
 - [Ethics & Algorithms Toolkit](http://ethicstoolkit.ai)
+- [Made by Human](https://madebyhuman.iamjarl.com) - Self-disclosure labeling system for human-AI collaboration in creative work `Open Source`
 - [Open Ethics Transparency Protocol (OETP)](https://openethics.ai/oetp/) `Open Ethics`
 - [RAI Toolkit](https://rai.tradewindai.com) `US Department of Defense`
 


### PR DESCRIPTION
Submitting [Made by Human](https://madebyhuman.iamjarl.com) — a self-disclosure labeling system for human-AI collaboration in creative work.

Conceptually adjacent to the existing [Open Ethics Transparency Protocol (OETP)](https://openethics.ai/oetp/) entry, but focused on creative output rather than automated decision-making systems.

- **Open source** (MIT) on [GitHub](https://github.com/JarlLyng/madebyhuman)
- **Free** SVG badges with copy-paste embed codes
- **Four signals:** Made by Human, Co-created with AI, Crafted by Human, Human in the Loop
- **Already listed** in [badges/awesome-badges](https://github.com/badges/awesome-badges)

Added in alphabetical position within the Frameworks section, between Ethics & Algorithms Toolkit and Open Ethics Transparency Protocol.