### PR TITLE
Add GenOps Framework to AI Governance tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -823,6 +823,7 @@ This section is under review and the rest of entries will be added to the table 
 
 Licensing AI models adds new layers of complexity beyond what traditional software licenses manage. Models may have separate licenses for: (1) The code used to train the model, (2) The model weights after training, (3) The datasets used during training, and (4) The outputs generated when users interact with the model.
 
+- [GenOps Framework](https://github.com/neerazz/genops-framework) `Neeraj Kumar Singh` - Open-source CI/CD governance framework for embedding generative AI agents into production pipelines. Provides risk-scored deployment gates, LLM audit logging, and policy-as-code controls. Companion to the JISEM paper [GenOps: Operationalizing Generative AI](https://jisem-journal.com/article/view/14322).
 - [Governance Mega-Map Application](https://github.com/The-Company-Ethos/doing-ai-governance) `The Company Ethos`
 
 ### AI Licensing


### PR DESCRIPTION
## Summary

Adds [GenOps Framework](https://github.com/neerazz/genops-framework) to the **AI Governance** section under Tools.

**What it is:** An open-source CI/CD governance framework for embedding generative AI agents into production pipelines. Provides:
- Risk-scored deployment gates that block unsafe agent rollouts
- Policy-as-code controls for LLM behavior governance
- LLM audit logging for accountability and compliance
- Integration with standard CI/CD tooling (GitHub Actions, Jenkins)

**Academic backing:** Companion to the peer-reviewed paper *GenOps: Operationalizing Generative AI* published in JISEM (Journal of Intelligent Systems and Engineering Management), DOI [10.52783/jisem.v11i1s.14322](https://jisem-journal.com/article/view/14322).

**Fit:** GenOps directly addresses the operational governance gap — how organizations enforce responsible AI policies at deployment time, not just during development. This complements the existing Governance Mega-Map Application entry.

## Checklist
- [x] Tool is open-source and publicly accessible
- [x] Description is accurate and concise
- [x] Peer-reviewed academic reference included
- [x] Placed in correct section (Tools > AI Governance)