### PR TITLE
Add ejentum-mcp under AI Alignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -818,6 +818,7 @@ This section is under review and the rest of entries will be added to the table 
 ### AI Alignment
 
 - [Circuit Breakers](https://github.com/GraySwanAI/circuit-breakers) `Python`
+- [ejentum-mcp](https://github.com/ejentum/ejentum-mcp) `Node.js` - Reasoning Harness with anti-deception cognitive scaffold injection for runtime sycophancy and hallucination resistance. Pre-generation scaffold ingestion (failure pattern, executable procedure, suppression vectors, falsification test) steers the model away from validation-pressure shortcuts and authority-appeal compliance. MIT, free tier 100 calls. ([Website](https://ejentum.com))
 
 ### AI Governance
 

--- a/README.md
+++ b/README.md
@@ -818,7 +818,7 @@ This section is under review and the rest of entries will be added to the table 
 ### AI Alignment
 
 - [Circuit Breakers](https://github.com/GraySwanAI/circuit-breakers) `Python`
-- [ejentum-mcp](https://github.com/ejentum/ejentum-mcp) `Node.js` - Reasoning Harness with anti-deception cognitive scaffold injection for runtime sycophancy and hallucination resistance. Pre-generation scaffold ingestion (failure pattern, executable procedure, suppression vectors, falsification test) steers the model away from validation-pressure shortcuts and authority-appeal compliance. MIT, free tier 100 calls. ([Website](https://ejentum.com))
+- [ejentum-mcp](https://github.com/ejentum/ejentum-mcp) `Node.js` - Reasoning Harness for runtime sycophancy and hallucination resistance: a library of 679 cognitive operations engineered in natural language across four harnesses. Each `harness_anti_deception` call retrieves a task-matched scaffold (failure pattern, executable procedure, suppression vectors, falsification test) the model ingests before responding, steering away from validation-pressure shortcuts and authority-appeal compliance. MIT, free tier 100 calls. ([Website](https://ejentum.com))
 
 ### AI Governance
 

--- a/README.md
+++ b/README.md
@@ -818,7 +818,7 @@ This section is under review and the rest of entries will be added to the table 
 ### AI Alignment
 
 - [Circuit Breakers](https://github.com/GraySwanAI/circuit-breakers) `Python`
-- [ejentum-mcp](https://github.com/ejentum/ejentum-mcp) `Node.js` - Reasoning Harness for runtime sycophancy and hallucination resistance: a library of 679 cognitive operations engineered in natural language across four harnesses. Each `harness_anti_deception` call retrieves a task-matched scaffold (failure pattern, executable procedure, suppression vectors, falsification test) the model ingests before responding, steering away from validation-pressure shortcuts and authority-appeal compliance. MIT, free tier 100 calls. ([Website](https://ejentum.com))
+- [ejentum-mcp](https://github.com/ejentum/ejentum-mcp) `Node.js` `Python` `TypeScript` - Reasoning harness for runtime sycophancy and hallucination resistance: a library of 679 cognitive operations across four harnesses (reasoning, code, anti-deception, memory). Each `harness_anti_deception` call retrieves a task-matched scaffold (named failure pattern, executable procedure, suppression vectors, falsification test) the model reads before responding. Twelve native framework integrations on PyPI/npm. MIT. ([Website](https://ejentum.com))
 
 ### AI Governance
 


### PR DESCRIPTION
Adds [ejentum-mcp](https://github.com/ejentum/ejentum-mcp) under **AI Alignment**, alphabetically after the existing `Circuit Breakers` entry.

**Why I think it fits the section.** Circuit Breakers is a runtime steering technique that intervenes in model behavior to prevent unsafe outputs. The ejentum-mcp anti-deception harness is the same architectural shape (runtime intervention) targeting a different failure mode: sycophancy, validation pressure, authority-appeal compliance, and hallucination drift instead of jailbreaks. Both are pre-generation interventions, not post-hoc filters. The section currently has only one entry; ours expands the runtime-steering tooling cluster.

**What it is.** MCP server (npm `ejentum-mcp`, MIT, free tier 100 calls) exposing four cognitive harness tools (`harness_reasoning`, `harness_code`, `harness_anti_deception`, `harness_memory`). Each call returns a structured cognitive scaffold the model ingests before generation: a named failure pattern, an executable procedure, suppression vectors that block the obvious shortcut, and a falsification test for self-verification. The anti-deception harness is the directly alignment-relevant component; the entry frames around that even though the project includes three other modes.

**Format.** Matched the existing Tools section style (`[Name](url) \`Lang\` - description ([Website](url))`) â€” I noticed the section uses both terse and elaborate entries depending on the project's surface; opted for elaborate since AI Alignment is a thin section and a one-line description helps readers decide if it fits their use.

Repo: MIT licensed, single repo containing the MCP server plus four SKILL.md files in `/skills/`, editor adapters in `/editors/` (Cursor/Windsurf/Cline), and an Anthropic Claude Code plugin manifest. Install: stdio via `npx -y ejentum-mcp`, or hosted HTTPS at `https://api.ejentum.com/mcp` (Bearer auth via `EJENTUM_API_KEY`, free tier 100 calls).

Maintainer is me; happy to address review feedback.