### PR TITLE
Add Audaria — French EU AI Act & ISO 42001 observatory

### DIFF
--- a/README.md
+++ b/README.md
@@ -407,6 +407,7 @@ This section features a curated selection of newsletters that keep you informed 
 - [AI Safety in China](https://aisafetychina.substack.com)
 - [AI Safety Newsletter](https://newsletter.safe.ai) `Center for AI Safety`
 - [AI Snake Oil](https://www.aisnakeoil.com)
+- [Audaria](https://audaria.fr)
 - [Import AI](importai.substack.com)
 - [Marcus on AI](https://garymarcus.substack.com)
 - [ML Safety Newsletter](https://newsletter.mlsafety.org)


### PR DESCRIPTION
Adds Audaria (https://audaria.fr) to the Newsletters section.

Audaria is a French-language editorial observatory on the EU AI Act (Regulation (EU) 2024/1689) and ISO/IEC 42001, publishing weekly analysis, sector studies and a glossary on AI governance and compliance.

- Placed alphabetically in ## Newsletters.
- Free, actively published, French-language — complements the existing English-language EU AI Act resources in the list.