### PR TITLE
Add Vaara to Audit section

### DIFF
--- a/README.md
+++ b/README.md
@@ -851,6 +851,7 @@ Licensing AI models adds new layers of complexity beyond what traditional softwa
 - [AIR Blackbox](https://github.com/airblackbox/gateway) `Python` - Open-source EU AI Act compliance scanner and runtime trust layer for Python AI agents. HMAC-SHA256 tamper-evident audit chains, PII detection, and prompt injection blocking. Trust layers for LangChain, CrewAI, AutoGen, OpenAI, Google ADK, and Claude Agent SDK. ([Website](https://airblackbox.ai) | [PyPI](https://pypi.org/project/air-blackbox/))
 - [glassalpha](https://github.com/asibic/glassalpha) `Python`
 - [Systima Comply](https://github.com/systima-ai/comply) `TypeScript` `Systima`
+- [Vaara](https://github.com/vaaraio/vaara) `Python` - Runtime risk-scoring and hash-chained audit trail for AI agent tool calls. Conformal prediction intervals, MWU online learning across five expert signals, EU AI Act Article 14 (human oversight) and Article 12 (record-keeping) evidence assembly. Apache-2.0.
 
 ### Causal Inference
 


### PR DESCRIPTION
Adds Vaara (https://github.com/vaaraio/vaara) to the Audit section.

Python library for runtime oversight of AI agents: intercepts tool calls, scores each one with a conformal risk interval, and writes a hash-chained audit record. Aligned with EU AI Act Article 14 (human oversight) and Article 12 (record-keeping). MWU online learning across five expert signals. Apache-2.0.

Vaara is also listed in `GenAI-Gurus/awesome-eu-ai-act` under AI Agent Governance (https://github.com/GenAI-Gurus/awesome-eu-ai-act).
