### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,7 +416,7 @@ This section features a curated selection of newsletters that keep you informed 
 - [The AI Evaluation Substack](https://aievaluation.substack.com)
 - [The EU AI Act Newsletter](https://artificialintelligenceact.substack.com)
 - [The Machine Learning Engineer](https://ethical.institute/mle.html)
-- [Turing Post](https://turingpost.substack.com)
+- [Turing Post](https://www.turingpost.com)
 
 ## Principles
 


### PR DESCRIPTION
The Turing Post link currently points to turingpost.substack.com, which is the old Substack mirror. The publication has fully migrated to its own domain. Updating to https://www.turingpost.com to point to the canonical source.