### PR TITLE
Add PRML / falsify to Audit section

### DIFF
--- a/README.md
+++ b/README.md
@@ -849,6 +849,7 @@ Licensing AI models adds new layers of complexity beyond what traditional softwa
 ### Audit
 
 - [AIR Blackbox](https://github.com/airblackbox/gateway) `Python` - Open-source EU AI Act compliance scanner and runtime trust layer for Python AI agents. HMAC-SHA256 tamper-evident audit chains, PII detection, and prompt injection blocking. Trust layers for LangChain, CrewAI, AutoGen, OpenAI, Google ADK, and Claude Agent SDK. ([Website](https://airblackbox.ai) | [PyPI](https://pypi.org/project/air-blackbox/))
+- [PRML / falsify](https://github.com/studio-11-co/falsify) `Python, JS, Go, Rust` `Studio 11` - Pre-Registered ML Manifest specification (CC BY 4.0). Commits an evaluation claim (metric, comparator, threshold, dataset hash, seed, producer identity) to a SHA-256 hash before the experiment runs. Tamper-evident audit trail; subcategory crosswalks for [EU AI Act Article 12](https://spec.falsify.dev/eu-ai-act/article-12/), [NIST AI RMF](https://spec.falsify.dev/nist-ai-rmf/), [ISO/IEC 42001](https://spec.falsify.dev/iso-42001/). Four byte-equivalent reference implementations across 20 conformance vectors. Zenodo DOI [10.5281/zenodo.20177839](https://doi.org/10.5281/zenodo.20177839), in [SchemaStore](https://www.schemastore.org/) catalog.
 - [glassalpha](https://github.com/asibic/glassalpha) `Python`
 - [Systima Comply](https://github.com/systima-ai/comply) `TypeScript` `Systima`
 


### PR DESCRIPTION
PRML (Pre-Registered ML Manifest) is an open specification for committing an ML evaluation claim — metric, comparator, threshold, dataset hash, seed, producer identity — to a SHA-256 hash before the experiment runs. Adding to **Audit** section since the entry directly above (AIR Blackbox) is the closest neighbour in scope: tamper-evident audit chains for AI evaluation evidence.

Why it fits:
- CC BY 4.0 spec, MIT code, Zenodo DOI [10.5281/zenodo.20177839](https://doi.org/10.5281/zenodo.20177839)
- Four byte-equivalent reference implementations (Python, JavaScript, Go, Rust) across 20 conformance vectors
- Subcategory crosswalks for [EU AI Act Article 12 logging](https://spec.falsify.dev/eu-ai-act/article-12/), [NIST AI RMF 1.0](https://spec.falsify.dev/nist-ai-rmf/), [ISO/IEC 42001:2023](https://spec.falsify.dev/iso-42001/) — each carries an "interpretive mapping, not legal advice" disclaimer
- JSON Schema in the [SchemaStore catalog](https://www.schemastore.org/) (autocomplete in VS Code / JetBrains / Helix / Zed / Cursor)

Spec deliberately does not claim regulatory acceptance; it is a per-claim commitment primitive, not a publication-integrity system (§8.1 of the spec).

Open to revisions on section placement, framing, or wording.