### PR TITLE
Add fmm-fairness-eval to Tools > Fairness

### DIFF
--- a/README.md
+++ b/README.md
@@ -910,6 +910,7 @@ Licensing AI models adds new layers of complexity beyond what traditional softwa
 - [faircause](https://github.com/dplecko/CFA) `R`
 - [Fairlearn](https://fairlearn.org) `Python` `Microsoft`
 - [fairmetrics](https://jianhuig.github.io/fairmetrics/) `R`
+- [fmm-fairness-eval](https://github.com/Ces107/fmm-fairness-eval-cli) `Python`
 - [Fairmodels](https://fairmodels.drwhy.ai) `R` `University of California`
 - [fairness](https://cran.r-project.org/web/packages/fairness/) `R`
 - [Fairness Indicators](https://github.com/tensorflow/fairness-indicators) `Python` `Google`


### PR DESCRIPTION
**Tool:** [fmm-fairness-eval](https://github.com/Ces107/fmm-fairness-eval-cli)
**PyPI:** `pip install --pre fmm-fairness-eval`
**License:** MIT
**Language:** Python 3.10+

A CLI for fairness evaluation of SaMD (Software as a Medical Device) AI models.

Fills a gap in the existing Fairness section: it treats hospital or site as a first-class protected attribute (the dominant failure mode for medical AI crossing hospital network boundaries), and emits EU AI Act Art. 9 and Art. 10 evidence artifacts with a SHA-256 audit chain. Metrics covered: equal opportunity gap, demographic parity gap, calibration gap (Brier, Hosmer-Lemeshow), inter-site AUC variance, intersectional gap with BCa confidence intervals and permutation p-values, composite SaMD fairness score.

Underlying research: Pereiro 2024, UPV, measuring a 0.19 inter-hospital F1 gap on AI4SkIN over CONCH foundation-model embeddings. https://riunet.upv.es/handle/10251/226903

Placed alphabetically between Fairlearn and fairmetrics in the Fairness subsection. No new section created. One entry per this PR.

Disclosure: I am the author.