### PR TITLE
Add Future AGI ai-evaluation and umbrella to LLM Evaluations and Benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1051,6 +1051,8 @@ Pre-registration and REporting Protocol for AI Evaluations](https://prep-eval.gi
 - [ForecastBench](https://www.forecastbench.org)
 - [ForesightSafety-Bench](https://github.com/Beijing-AISI/ForesightSafety-Bench) `Python` `Beijing AISI`
 - [FrontierMath](https://epoch.ai/frontiermath)
+- [Future AGI ai-evaluation](https://github.com/future-agi/ai-evaluation) `Python` Open-source LLM evaluation framework with 50+ metrics, LLM-as-Judge augmentation, and guardrail scanners (jailbreak, PII, prompt-injection); AutoEval pipelines with CI/CD support.
+- [Future AGI](https://github.com/future-agi/future-agi) Open-source self-hostable end-to-end agent engineering and optimization platform unifying tracing, evaluation, simulation, datasets, gateway, and guardrails in one feedback loop.
 - [Geekbench AI](https://www.geekbench.com/ai/)
 - [GDPval](https://huggingface.co/datasets/openai/gdpval) [Paper](https://cdn.openai.com/pdf/d5eb7428-c4e9-4a33-bd86-86dd4bcf12ce/GDPval.pdf) `OpenAI`
 - [GPQA: A Graduate-Level Google-Proof Q&A Benchmark](https://github.com/idavidrein/gpqa) `Python` `dataset` [Epoch Dashboard](https://epoch.ai/benchmarks/gpqa-diamond?view=graph&tab=release-date)


### PR DESCRIPTION
This PR adds open-source Future AGI projects to the most relevant section(s) of the list.

All entries are Apache 2.0 licensed.

- traceAI: https://github.com/future-agi/traceAI
- ai-evaluation: https://github.com/future-agi/ai-evaluation
- agent-opt: https://github.com/future-agi/agent-opt
- simulate-sdk: https://github.com/future-agi/simulate-sdk
- agent-command-center-sdk: https://github.com/future-agi/agent-command-center-sdk
- future-agi (umbrella): https://github.com/future-agi/future-agi
- futureagi-mcp-server: https://github.com/future-agi/futureagi-mcp-server

Description style and placement match the existing entries in the chosen section. Single-purpose diff: only README updates.