### PR TITLE
Add eu-ai-act-checklist to EU AI Act Compliance section

### DIFF
--- a/README.md
+++ b/README.md
@@ -900,6 +900,7 @@ Licensing AI models adds new layers of complexity beyond what traditional softwa
  
 - [AI Act Skills](https://github.com/abk1969/ai-act-skills) `Skills` `Gemini` `Claude` `OpenAI`
 - [EuConform](https://euconform.eu) `Python`
+- [eu-ai-act-checklist](https://github.com/GatisOzols/eu-ai-act-checklist) `Markdown` `Python` `JSON` - Open-source compliance checklist for Regulation (EU) 2024/1689. 7-step self-audit, Annex III mapping, Article 50 disclosure templates (chatbot, synthetic content, deepfake, emotion recognition), Python risk classifier, Article 99 penalty bands as JSON. MIT.
 
 ### Fairness
 


### PR DESCRIPTION
Adding [eu-ai-act-checklist](https://github.com/GatisOzols/eu-ai-act-checklist) to the EU AI Act Compliance subsection.

It's an MIT-licensed practical compliance checklist for Regulation (EU) 2024/1689:

- 7-step self-audit (`checklist.md`)
- Machine-readable Annex III high-risk mapping (`annex-iii-categories.json`)
- Copy-paste Article 50 disclosure templates: chatbot, synthetic content, deepfake, emotion recognition
- Small Python decision-tree classifier (`classify.py`)
- Article 99 penalty bands as JSON

Built for SaaS founders and AI product teams ahead of the 2 August 2026 application date.

Disclosure: I'm the founder of Disclos, the team maintaining the repo. The repo stays free and MIT regardless.