### PR TITLE
Add AI Act Companion under Tools / EU AI Act Compliance

### DIFF
--- a/README.md
+++ b/README.md
@@ -898,6 +898,7 @@ Licensing AI models adds new layers of complexity beyond what traditional softwa
 
 ### EU AI Act Compliance
  
+- [AI Act Companion](https://github.com/JKasteele/ai-act-companion) `Python`
 - [AI Act Skills](https://github.com/abk1969/ai-act-skills) `Skills` `Gemini` `Claude` `OpenAI`
 - [EuConform](https://euconform.eu) `Python`
 


### PR DESCRIPTION
Thanks for maintaining this list! Adding **[AI Act Companion](https://github.com/JKasteele/ai-act-companion)** under *Tools → EU AI Act Compliance* — a free, open-source (MIT), local-first EU AI Act risk classifier in Python.

- Deterministic & cited: every tier verdict links to the exact Article/Annex.
- Adds an architecture-aware AI-security lens (OWASP LLM Top 10, MITRE ATLAS, STRIDE) and generates DPIA, Annex IV, FRIA, a conformity tracker and a post-market monitoring plan; NIST AI RMF + ISO/IEC 42001 crosswalks.
- [Live demo](https://huggingface.co/spaces/JesseKasteele/ai-act-companion) (synthetic data only); tests + CI.

Placed alphabetically, matching the section's `[Name](url) \`Tag\`` format. Happy to adjust — thanks for considering!