### PR TITLE
Add AI Law Radar to Regulations › Interesting resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -471,6 +471,7 @@ Regulations are requirements established by governments.
 
 ### Interesting resources
 
+- [AI Law Radar](https://ailawradar.com)
 - [AI Regulations Tracker](https://regulations.ai/regulations/tracker)
 - [Data Protection and Privacy Legislation Worldwide](https://unctad.org/page/data-protection-and-privacy-legislation-worldwide) `UNCTAD`
 - [Data Protection Laws of the Word](https://www.dlapiperdataprotection.com) `DLAPiper`


### PR DESCRIPTION
Adds [AI Law Radar](https://ailawradar.com) — a free, open (CC BY 4.0) tracker of AI-law obligations and deadlines across 13 jurisdictions. Every entry links to its primary source and is re-verified daily; there is a public REST API + MCP endpoint, an embeddable widget, and calendar/CSV export. Not legal advice. Thanks for maintaining this list!