### PR TITLE
Add AI Readiness & Governance Starter Kit to RAI Toolkit

### DIFF
--- a/README.md
+++ b/README.md
@@ -1282,6 +1282,7 @@ For consumers:
 
 ### (RAI) Toolkit
 
+- [AI Readiness & Governance Starter Kit](https://github.com/tinyopsstudio/ai-readiness-governance-kit) `Governance` `Templates`
 - [Deepchecks](https://github.com/deepchecks/deepchecks) `Python`
 - [Dr. Why](https://github.com/ModelOriented/DrWhy) `R` `Warsaw University of Technology`
 - [Mercury](https://www.bbvaaifactory.com/mercury/) `Python` `BBVA`


### PR DESCRIPTION
Adds a free, MIT-licensed readiness and governance template set to the Responsible AI Toolkit section.\n\nThe repository includes a readiness questionnaire plus CSV templates for use-case prioritization, governance gaps, vendor evaluation, and 60-day action planning.\n\nChecks:\n- Target link returns HTTP 200\n- README diff check passes\n- One-line addition using the section's existing format