### PR TITLE
Add EU AI Act Risk Checker to Tools › EU AI Act Compliance

### DIFF
--- a/README.md
+++ b/README.md
@@ -909,6 +909,7 @@ Licensing AI models adds new layers of complexity beyond what traditional softwa
 - [AI Act Skills](https://github.com/abk1969/ai-act-skills) `Skills` `Gemini` `Claude` `OpenAI`
 - [EuConform](https://euconform.eu) `Python`
 - [eu-ai-act-checklist](https://github.com/GatisOzols/eu-ai-act-checklist) `Markdown` `Python` `JSON`
+- [EU AI Act Risk Checker](https://cruxdigits.nl/eu-ai-act-risk-checker/) `JavaScript` `Open Source`
 - [YRproject](https://yrproject.nl)
 
 ### Fairness


### PR DESCRIPTION
Adds **EU AI Act Risk Checker** to *Tools → EU AI Act Compliance*.

Free, open-source (MIT), client-side tool: 4 questions → your AI system's EU AI Act risk tier (prohibited / high / limited / minimal + GPAI), with obligations and compliance deadlines. Based on Regulation (EU) 2024/1689. No backend or tracking; bilingual EN/NL.

- Live: https://cruxdigits.nl/eu-ai-act-risk-checker/
- Source (MIT): https://github.com/tomdxb0004/eu-ai-act-risk-checker

Not legal advice — a fast triage. Happy to adjust tags/placement to fit the list.