### PR TITLE
Add GOPAL to Frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,6 +312,7 @@ This section is under review and the rest of entries will be added to the table 
 - [Data Ethics Canvas](https://theodi.org/insights/tools/the-data-ethics-canvas-2021/) `Open Data Institute`
 - [Deon](https://deon.drivendata.org) `Python` `Drivendata`
 - [Ethics & Algorithms Toolkit](http://ethicstoolkit.ai)
+- [GOPAL](https://github.com/Principled-Evolution/gopal) - 66 executable Rego policies encoding EU AI Act, NIST AI RMF, education, and banking AI-governance requirements; run with Open Policy Agent, versioned with semver guarantees. `Rego` `OPA` `Principled Evolution`
 - [Open Ethics Transparency Protocol (OETP)](https://openethics.ai/oetp/) `Open Ethics`
 - [RAI Toolkit](https://rai.tradewindai.com) `US Department of Defense`
 


### PR DESCRIPTION
Adding GOPAL under Frameworks: an open-source Rego policy library covering EU AI Act, NIST AI RMF, education, and banking AI-governance rules (66 policies total), runnable with Open Policy Agent.

Placed it alphabetically between Ethics & Algorithms Toolkit and OETP to match how the rest of the section is ordered. Happy to adjust if you'd rather it live somewhere else.