### PR TITLE
Add EU AI Act Obligation-to-Evidence Dataset to Data Sets

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,7 @@ This section features a curated selection of data sets.
 - [Huggingface Data Sets](https://huggingface.co/datasets)
 - [The Stack](https://www.bigcode-project.org/docs/about/the-stack/)
 - [Open Ethics Data Passport](https://openethics.ai/oedp/) `Open Ethics`
+- [EU AI Act Obligation-to-Evidence Dataset](https://github.com/Kroniquedubaboo/eu-ai-act-obligation-evidence-dataset) `CC BY 4.0`
 
 If you are looking for public data sets for your project, this is a [curated collection](https://github.com/awesomedata/awesome-public-datasets).
 


### PR DESCRIPTION
Adds one entry to **Data Sets**: [EU AI Act Obligation-to-Evidence Dataset](https://github.com/Kroniquedubaboo/eu-ai-act-obligation-evidence-dataset) — an open, machine-readable dataset (JSON/CSV + an integrity validator) mapping EU AI Act obligations to the specific audit evidence, roles, risk tiers and deadlines. Licensed CC BY 4.0; every record cites a primary source. It sits alongside the other open datasets in that section; the EU AI Act regulation itself is already covered under Regulations, so this is not a duplicate. Not legal advice.