### PR TITLE
Add RAI Toolkit (W&B) to Tools > AI Governance

### DIFF
--- a/README.md
+++ b/README.md
@@ -845,6 +845,7 @@ This section is under review and the rest of entries will be added to the table 
 
 - [Agent Governance Toolkit](https://github.com/microsoft/agent-governance-toolkit) `Microsoft`
 - [Governance Mega-Map Application](https://github.com/The-Company-Ethos/doing-ai-governance) `The Company Ethos`
+- [RAI Toolkit](https://github.com/wandb/rai-toolkit) `Python` `Weights & Biases` - Evidence-backed AI review gates for LLM apps: compliance-aware evals, red-team probes, policy-as-code, and approval records mapped to NIST AI RMF, EU AI Act, and the MIT AI Risk Repository.
 - [Verifywise](https://github.com/verifywise-ai/verifywise) `VerifyWise`
 - [Venturalitica SDK](https://github.com/Venturalitica/venturalitica-sdk)
 


### PR DESCRIPTION
Adds [RAI Toolkit](https://github.com/wandb/rai-toolkit) to the Tools > AI Governance subsection.

RAI Toolkit is an Apache-2.0 open-source toolkit that turns AI risk reviews into evidence-backed release decisions for LLM apps: one-command assessments combining compliance-aware evals, a 32-attack red-team suite, policy-as-code (YAML), and reviewer-led probing, with framework coverage mapped to NIST AI RMF 1.0, EU AI Act (Articles 9-15), and the MIT AI Risk Repository. Ships industry presets (healthcare, financial services, government) and exports JSON/HTML approval records.

Placed alphabetically within the subsection, matching the existing entry format.