### PR TITLE
Add Fair Code to Tools > Fairness

### DIFF
--- a/README.md
+++ b/README.md
@@ -924,6 +924,7 @@ Licensing AI models adds new layers of complexity beyond what traditional softwa
 - [EquiPy](https://github.com/equilibration/equipy) `Python`
 - [fairadapt](https://cran.r-project.org/web/packages/fairadapt/index.html) `R`
 - [faircause](https://github.com/dplecko/CFA) `R`
+- [Fair Code](https://github.com/yakew7/Fair-Code) `Python`
 - [Fairlearn](https://fairlearn.org) `Python` `Microsoft`
 - [fairmetrics](https://jianhuig.github.io/fairmetrics/) `R`
 - [fmm-fairness-eval](https://github.com/Ces107/fmm-fairness-eval-cli) `Python`


### PR DESCRIPTION
I'm the author of Fair Code and am submitting it for inclusion in this list.

Fair Code (https://github.com/yakew7/Fair-Code, site: thefaircode.xyz) is an open-source project that audits real-world-style AI systems for algorithmic bias across 7 domains: criminal justice (COMPAS), hiring, lending, insurance, welfare, hospital readmission, and tenant screening. Each audit ships a biased baseline model alongside a mitigated version, with measured before/after fairness metrics, Jupyter notebooks, a benchmark harness, and a client-side dataset bias profiler. It's MIT licensed and written in Python.

I added it to Tools > Fairness rather than the top-level Frameworks section, since that section covers general ethical-decision frameworks (Data Ethics Canvas, Deon, etc.) while Tools > Fairness is the list of concrete bias-audit/mitigation tooling (Aequitas, AIF360, Fairlearn) that Fair Code is a direct peer of.